### PR TITLE
adds gulp.plumber & gulp.notify to show errors on gulp default task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,8 +18,6 @@ var gulp        = require('gulp'),
 		notify      = require('gulp-notify');
 
 
-
-
 gulp.task('scss', function() {
 	var onError = function(err) {
     notify.onError({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,22 +14,23 @@ var gulp        = require('gulp'),
     size        = require('gulp-size'),
     imagemin    = require('gulp-imagemin'),
     pngquant    = require('imagemin-pngquant'),
-		plumber     = require('gulp-plumber'),
-		notify      = require('gulp-notify');
+    plumber     = require('gulp-plumber'),
+    notify      = require('gulp-notify');
 
 
 gulp.task('scss', function() {
-	var onError = function(err) {
-    notify.onError({
-			title:    "Gulp",
-			subtitle: "Failure!",
-			message:  "Error: <%= error.message %>",
-			sound:    "Beep"
-		})(err);
-    this.emit('end');
+    var onError = function(err) {
+      notify.onError({
+          title:    "Gulp",
+          subtitle: "Failure!",
+          message:  "Error: <%= error.message %>",
+          sound:    "Beep"
+      })(err);
+      this.emit('end');
   };
+  
   return gulp.src('scss/main.scss')
-	  .pipe(plumber({errorHandler: onError}))
+    .pipe(plumber({errorHandler: onError}))
     .pipe(sass())
     .pipe(size({ gzip: true, showFiles: true }))
     .pipe(prefix())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,10 +13,25 @@ var gulp        = require('gulp'),
     minifyHTML  = require('gulp-minify-html'),
     size        = require('gulp-size'),
     imagemin    = require('gulp-imagemin'),
-    pngquant    = require('imagemin-pngquant');
+    pngquant    = require('imagemin-pngquant'),
+		plumber     = require('gulp-plumber'),
+		notify      = require('gulp-notify');
+
+
+
 
 gulp.task('scss', function() {
+	var onError = function(err) {
+    notify.onError({
+			title:    "Gulp",
+			subtitle: "Failure!",
+			message:  "Error: <%= error.message %>",
+			sound:    "Beep"
+		})(err);
+    this.emit('end');
+  };
   return gulp.src('scss/main.scss')
+	  .pipe(plumber({errorHandler: onError}))
     .pipe(sass())
     .pipe(size({ gzip: true, showFiles: true }))
     .pipe(prefix())
@@ -26,7 +41,7 @@ gulp.task('scss', function() {
     .pipe(cssmin())
     .pipe(size({ gzip: true, showFiles: true }))
     .pipe(rename({ suffix: '.min' }))
-    .pipe(gulp.dest('dist/css'));
+    .pipe(gulp.dest('dist/css'))
 });
 
 gulp.task('browser-sync', function() {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "gulp-jshint": "^1.9.0",
     "gulp-minify-css": "^0.3.12",
     "gulp-minify-html": "^0.1.8",
+    "gulp-notify": "^2.2.0",
+    "gulp-plumber": "^0.6.6",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^1.3.2",
     "gulp-scss-lint": "^0.1.6",


### PR DESCRIPTION
Fixes #1 by adding gulp.plumber and gulp.notify to 

a) keep gulp.watch running if there's an error
b) give and audible and visual notification of the error
