### PR TITLE
Use gulp-load-plugins to manage plugins

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,27 +1,18 @@
 var gulp        = require('gulp'),
-    sass        = require('gulp-sass'),
-    rename      = require('gulp-rename'),
-    cssmin      = require('gulp-minify-css'),
-    concat      = require('gulp-concat'),
-    uglify      = require('gulp-uglify'),
-    jshint      = require('gulp-jshint'),
-    scsslint    = require('gulp-scss-lint'),
-    cache       = require('gulp-cached'),
-    prefix      = require('gulp-autoprefixer'),
     browserSync = require('browser-sync'),
     reload      = browserSync.reload,
-    minifyHTML  = require('gulp-minify-html'),
-    size        = require('gulp-size'),
-    imagemin    = require('gulp-imagemin'),
     pngquant    = require('imagemin-pngquant'),
-    plumber     = require('gulp-plumber'),
     deploy      = require('gulp-gh-pages'),
-    notify      = require('gulp-notify');
-
+    $           = require('gulp-load-plugins')({
+                    rename: {
+                      'gulp-minify-html': 'minifyHTML',
+                      'gulp-minify-css': 'cssmin'
+                    }
+                  });
 
 gulp.task('scss', function() {
     var onError = function(err) {
-      notify.onError({
+      $.notify.onError({
           title:    "Gulp",
           subtitle: "Failure!",
           message:  "Error: <%= error.message %>",
@@ -31,16 +22,16 @@ gulp.task('scss', function() {
   };
 
   return gulp.src('scss/main.scss')
-    .pipe(plumber({errorHandler: onError}))
-    .pipe(sass())
-    .pipe(size({ gzip: true, showFiles: true }))
-    .pipe(prefix())
-    .pipe(rename('main.css'))
+    .pipe($.plumber({errorHandler: onError}))
+    .pipe($.sass())
+    .pipe($.size({ gzip: true, showFiles: true }))
+    .pipe($.autoprefixer())
+    .pipe($.rename('main.css'))
     .pipe(gulp.dest('dist/css'))
     .pipe(reload({stream:true}))
-    .pipe(cssmin())
-    .pipe(size({ gzip: true, showFiles: true }))
-    .pipe(rename({ suffix: '.min' }))
+    .pipe($.cssmin())
+    .pipe($.size({ gzip: true, showFiles: true }))
+    .pipe($.rename({ suffix: '.min' }))
     .pipe(gulp.dest('dist/css'))
 });
 
@@ -59,17 +50,17 @@ gulp.task('deploy', function () {
 
 gulp.task('js', function() {
   gulp.src('js/*.js')
-    .pipe(uglify())
-    .pipe(size({ gzip: true, showFiles: true }))
-    .pipe(concat('j.js'))
+    .pipe($.uglify())
+    .pipe($.size({ gzip: true, showFiles: true }))
+    .pipe($.concat('j.js'))
     .pipe(gulp.dest('dist/js'))
     .pipe(reload({stream:true}));
 });
 
 gulp.task('scss-lint', function() {
   gulp.src('scss/**/*.scss')
-    .pipe(cache('scsslint'))
-    .pipe(scsslint());
+    .pipe($.cache('scsslint'))
+    .pipe($.scsslint());
 });
 
 gulp.task('minify-html', function() {
@@ -79,15 +70,15 @@ gulp.task('minify-html', function() {
     };
 
   gulp.src('./*.html')
-    .pipe(minifyHTML(opts))
+    .pipe($.minifyHTML(opts))
     .pipe(gulp.dest('dist/'))
     .pipe(reload({stream:true}));
 });
 
 gulp.task('jshint', function() {
   gulp.src('dist/js/j.js')
-    .pipe(jshint())
-    .pipe(jshint.reporter('default'));
+    .pipe($.jshint())
+    .pipe($.jshint.reporter('default'));
 });
 
 gulp.task('watch', function() {
@@ -99,7 +90,7 @@ gulp.task('watch', function() {
 
 gulp.task('imgmin', function () {
     return gulp.src('img/*')
-        .pipe(imagemin({
+        .pipe($.imagemin({
             progressive: true,
             svgoPlugins: [{removeViewBox: false}],
             use: [pngquant()]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gulp-gh-pages": "^0.4.0",
     "gulp-imagemin": "^2.1.0",
     "gulp-jshint": "^1.9.0",
+    "gulp-load-plugins": "^1.0.0-rc.1",
     "gulp-minify-css": "^0.3.12",
     "gulp-minify-html": "^0.1.8",
     "gulp-notify": "^2.2.0",


### PR DESCRIPTION
Nothing major, just tidies up the start of the gulpfile a bit and saves a bit of time when adding new plugins.

Great boilerplate for gulp, saves so much time with setup to know it's all there already!
